### PR TITLE
Fix management dashboard date handling

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -719,15 +719,28 @@ function saveProductSales(salesData, date) {
 
 // FIXED: Replace generateDailyReport function in Code.gs with proper date handling
 
+// Helper to robustly parse a date string in either ISO (yyyy-mm-dd) or native formats
+function parseInputDate(date) {
+  if (typeof date !== 'string') {
+    return new Date(date);
+  }
+
+  // ISO format (e.g. 2024-07-26)
+  if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return new Date(date + 'T12:00:00');
+  }
+
+  // Fallback to default Date parsing
+  return new Date(date);
+}
+
 function generateDailyReport(date) {
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
-    
-    // Fix the date comparison - convert input date to proper format
+
     let targetDateString;
     if (date) {
-      // If date is passed as string like "2025-07-25", convert it properly
-      const targetDate = new Date(date + 'T12:00:00'); // Add time to avoid timezone issues
+      const targetDate = parseInputDate(date);
       targetDateString = targetDate.toDateString();
     } else {
       targetDateString = new Date().toDateString();

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -38,20 +38,22 @@ function ManagementDashboard() {
             console.log("Selected period:", selectedPeriod);
             console.log("Custom date:", customDate);
             
+            const formatISO = (d) => d.toISOString().split('T')[0];
+
             if (selectedPeriod === 'custom' && customDate) {
-                dateParam = new Date(customDate).toDateString();
+                dateParam = formatISO(new Date(customDate));
             } else if (selectedPeriod === 'today') {
-                dateParam = new Date().toDateString();
+                dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'yesterday') {
                 const yesterday = new Date();
                 yesterday.setDate(yesterday.getDate() - 1);
-                dateParam = yesterday.toDateString();
+                dateParam = formatISO(yesterday);
             } else if (selectedPeriod === 'week') {
                 // For week, we'll use today's date but the backend can handle week logic
-                dateParam = new Date().toDateString();
+                dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'month') {
                 // For month, we'll use today's date but the backend can handle month logic
-                dateParam = new Date().toDateString();
+                dateParam = formatISO(new Date());
             }
             
             console.log("Requesting data for date:", dateParam);

--- a/index.html
+++ b/index.html
@@ -567,25 +567,26 @@
         
         try {
             let dateParam = null;
-            
+            const formatISO = (d) => d.toISOString().split('T')[0];
+
             if (selectedPeriod === 'today') {
-                dateParam = new Date().toDateString();
+                dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'yesterday') {
                 const yesterday = new Date();
                 yesterday.setDate(yesterday.getDate() - 1);
-                dateParam = yesterday.toDateString();
+                dateParam = formatISO(yesterday);
             } else if (selectedPeriod === 'custom') {
                 if (customDate) {
                     const selectedDate = new Date(customDate);
-                    dateParam = selectedDate.toDateString();
+                    dateParam = formatISO(selectedDate);
                 } else {
                     setLoading(false);
                     return; // Don't load data if no custom date selected
                 }
             } else if (selectedPeriod === 'week') {
-                dateParam = new Date().toDateString();
+                dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'month') {
-                dateParam = new Date().toDateString();
+                dateParam = formatISO(new Date());
             }
             
             console.log("Selected period:", selectedPeriod);


### PR DESCRIPTION
## Summary
- parse date strings in `generateDailyReport` using new helper `parseInputDate`
- request reports using ISO format dates in `ManagementDashboard.html`
- ensure built-in ManagementTab also sends ISO date strings

## Testing
- `node -e "console.log(new Date('Fri Jul 26 2024').toString());"`
- `node -e "console.log(new Date('Fri Jul 26 2024T12:00:00').toString());"`

------
https://chatgpt.com/codex/tasks/task_e_6888ba6ba66c832582b41a2a60dcb527