### PR TITLE
Fix custom date loading in dashboard

### DIFF
--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -16,7 +16,9 @@ function ManagementDashboard() {
     const [showDebugData, setShowDebugData] = React.useState(false);
 
     React.useEffect(() => {
-        loadDashboardData();
+        if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
+            loadDashboardData();
+        }
     }, [selectedPeriod, customDate]);
 
     const loadDashboardData = async () => {


### PR DESCRIPTION
## Summary
- update `useEffect` in **ManagementDashboard.html** so the dashboard refreshes only when a date is chosen for custom period

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888cfcfa6a883258b602c194554ff3c