### PR TITLE
Add employee entry page and metrics toggle

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -144,6 +144,15 @@ function doGet(e) {
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
 
+function doGetEmployee(e) {
+  initializeDatabase();
+  return HtmlService.createTemplateFromFile('employee_index')
+    .evaluate()
+    .setTitle('Employee Daily Entry')
+    .addMetaTag('viewport','width=device-width, initial-scale=1')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
 // Include HTML files
 function include(filename) {
   return HtmlService.createHtmlOutputFromFile(filename).getContent();

--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -1,5 +1,5 @@
 <script type="text/babel">
-function DailyEntryTab() {
+function DailyEntryTab({ showMetrics = true }) {
     const { state, setState } = React.useContext(window.AppContext);
     const [pinError, setPinError] = React.useState(false);
     const [pinAttempted, setPinAttempted] = React.useState(false);
@@ -1121,7 +1121,7 @@ const entryData = {
                     ),
                     
                     // Enhanced Calculated Metrics Display with dynamic ranges and alerts
-                    calculatedMetrics && React.createElement('div', {
+                    showMetrics && calculatedMetrics && React.createElement('div', {
                         className: 'mt-6 space-y-4'
                     },
                         // Alerts section
@@ -1397,7 +1397,7 @@ const entryData = {
                     ),
                     
                     // Sales Metrics Display
-                    calculatedMetrics && calculatedMetrics.sales && React.createElement('div', {
+                    showMetrics && calculatedMetrics && calculatedMetrics.sales && React.createElement('div', {
                         className: 'mt-4 p-4 bg-gray-50 rounded-lg'
                     },
                         React.createElement('h4', {

--- a/employee_index.html
+++ b/employee_index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Employee Daily Entry</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        olive: {
+                            50: '#f7f8f0',
+                            100: '#eef0dc',
+                            200: '#dde2bd',
+                            300: '#c6ce94',
+                            400: '#b0ba70',
+                            500: '#9ca653',
+                            600: '#84a35a',
+                            700: '#6a7c47',
+                            800: '#56653c',
+                            900: '#4a5735',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+    <div id="loading" class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-olive-50 to-olive-100">
+        <div class="animate-spin rounded-full h-16 w-16 border-b-2 border-olive-600 mb-4"></div>
+        <div class="text-olive-600 text-lg">Loading...</div>
+    </div>
+    <div id="root" style="display:none;"></div>
+
+    <script type="text/babel">
+        window.AppContext = React.createContext();
+
+        function EmployeeApp() {
+            const [state, setState] = React.useState({});
+            return React.createElement(window.AppContext.Provider, { value: { state, setState } },
+                React.createElement('div', { className: 'container mx-auto px-4 py-8' },
+                    React.createElement(DailyEntryTab, { showMetrics: false })
+                )
+            );
+        }
+
+        window.initializeEmployeeApp = function() {
+            ReactDOM.render(React.createElement(EmployeeApp), document.getElementById('root'));
+        };
+    </script>
+
+    <?!= include('DailyEntryTab'); ?>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('root').style.display = 'block';
+            window.initializeEmployeeApp();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow DailyEntryTab to hide metrics using a showMetrics prop
- gate metrics rendering on the new prop
- add employee_index.html with a simplified EmployeeApp
- expose `doGetEmployee` to serve the employee page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889f84329f483258f462ca2ffb0ad8e